### PR TITLE
No packages to validate when only package descriptor is changed in Fast Feedback

### DIFF
--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -26,7 +26,7 @@
             "path": "./src/frameworks/feature-mgmt",
             "package": "feature-mgmt",
             "versionName": "Version 1.0.3",
-            "versionNumber": "1.0.3.0"
+            "versionNumber": "1.0.3.4"
         },
         {
             "path": "./src/core-crm",


### PR DESCRIPTION
This PR checks change in package descriptor in fast-feedback mode. This should not build anything as package descriptor is ignored